### PR TITLE
Feat: add codes to errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -384,7 +384,7 @@ class Plugin extends MiniAccountsPlugin {
 
         return this.ilpAndCustomToProtocolData({ ilp: response })
       } catch (e) {
-        return this.ilpAndCustomToProtocolData({ ilp: IlpPacket.errorToReject(e) })
+        return this.ilpAndCustomToProtocolData({ ilp: IlpPacket.errorToReject(this._prefix, e) })
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const crypto = require('crypto')
 const IlpPacket = require('ilp-packet')
+const { Errors } = IlpPacket
 const { Writer } = require('oer-utils')
 const nacl = require('tweetnacl')
 const { RippleAPI } = require('ripple-lib')
@@ -345,42 +346,46 @@ class Plugin extends MiniAccountsPlugin {
 
     // in the case of an ilp message, we behave as a connector
     if (ilp) {
-      if (ilp.data[0] === IlpPacket.Type.TYPE_ILP_PREPARE) {
-        this._handleIncomingPrepare(account, ilp.data)
-      }
-
-      // TODO: don't do this, use connector only instead
-      if (ilp.data[0] === IlpPacket.Type.TYPE_ILP_PREPARE && IlpPacket.deserializeIlpPrepare(ilp.data).destination === 'peer.config') {
-        const writer = new Writer()
-        const response = this._prefix + account.getAccount()
-        writer.writeVarOctetString(Buffer.from(response))
-
-        return [{
-          protocolName: 'ilp',
-          contentType: BtpPacket.MIME_APPLICATION_OCTET_STRING,
-          data: IlpPacket.serializeIlpFulfill({
-            fulfillment: Buffer.alloc(32),
-            data: writer.getBuffer()
-          })
-        }]
-      }
-
-      let response = await Promise.race([
-        this._dataHandler(ilp.data),
-        this._expireData(account, ilp.data)
-      ])
-
-      if (ilp.data[0] === IlpPacket.Type.TYPE_ILP_PREPARE) {
-        if (response[0] === IlpPacket.Type.TYPE_ILP_REJECT) {
-          this._rejectIncomingTransfer(account, ilp.data)
-        } else if (response[0] === IlpPacket.Type.TYPE_ILP_FULFILL) {
-          // TODO: should await, or no?
-          const { amount } = IlpPacket.deserializeIlpPrepare(ilp.data)
-          if (amount !== '0' && this._moneyHandler) this._moneyHandler(amount)
+      try {
+        if (ilp.data[0] === IlpPacket.Type.TYPE_ILP_PREPARE) {
+          this._handleIncomingPrepare(account, ilp.data)
         }
-      }
 
-      return this.ilpAndCustomToProtocolData({ ilp: response })
+        // TODO: don't do this, use connector only instead
+        if (ilp.data[0] === IlpPacket.Type.TYPE_ILP_PREPARE && IlpPacket.deserializeIlpPrepare(ilp.data).destination === 'peer.config') {
+          const writer = new Writer()
+          const response = this._prefix + account.getAccount()
+          writer.writeVarOctetString(Buffer.from(response))
+
+          return [{
+            protocolName: 'ilp',
+            contentType: BtpPacket.MIME_APPLICATION_OCTET_STRING,
+            data: IlpPacket.serializeIlpFulfill({
+              fulfillment: Buffer.alloc(32),
+              data: writer.getBuffer()
+            })
+          }]
+        }
+
+        let response = await Promise.race([
+          this._dataHandler(ilp.data),
+          this._expireData(account, ilp.data)
+        ])
+
+        if (ilp.data[0] === IlpPacket.Type.TYPE_ILP_PREPARE) {
+          if (response[0] === IlpPacket.Type.TYPE_ILP_REJECT) {
+            this._rejectIncomingTransfer(account, ilp.data)
+          } else if (response[0] === IlpPacket.Type.TYPE_ILP_FULFILL) {
+            // TODO: should await, or no?
+            const { amount } = IlpPacket.deserializeIlpPrepare(ilp.data)
+            if (amount !== '0' && this._moneyHandler) this._moneyHandler(amount)
+          }
+        }
+
+        return this.ilpAndCustomToProtocolData({ ilp: response })
+      } catch (e) {
+        return this.ilpAndCustomToProtocolData({ ilp: IlpPacket.errorToReject(e) })
+      }
     }
 
     return []
@@ -416,14 +421,14 @@ class Plugin extends MiniAccountsPlugin {
     await new Promise((resolve) => setTimeout(resolve, expiresAt - Date.now()))
     return isPrepare
       ? IlpPacket.serializeIlpReject({
-        code: 'F00',
+        code: 'R00',
         triggeredBy: this._prefix, // TODO: is that right?
         message: 'expired at ' + new Date().toISOString(),
         data: Buffer.from('')
       })
       : IlpPacket.serializeIlpError({
-        code: 'F00',
-        name: 'Bad Request',
+        code: 'R00',
+        name: 'Transfer Timed Out',
         triggeredBy: this._prefix + account.getAccount(),
         forwardedBy: [],
         triggeredAt: new Date(),
@@ -437,12 +442,12 @@ class Plugin extends MiniAccountsPlugin {
     const { amount } = IlpPacket.deserializeIlpPrepare(ilpData)
 
     if (!account.getPaychan()) {
-      throw new Error(`Incoming traffic won't be accepted until a channel
+      throw new Errors.UnreachableError(`Incoming traffic won't be accepted until a channel
         to the connector is established.`)
     }
 
     if (account.isBlocked()) {
-      throw new Error('This account has been closed.')
+      throw new Errors.UnreachableError('This account has been closed.')
     }
 
     const lastValue = account.getIncomingClaim().amount
@@ -454,12 +459,13 @@ class Plugin extends MiniAccountsPlugin {
       newPrepared.toString(), 'prepared', prepared.toString())
 
     if (unsecured.gt(this._bandwidth)) {
-      throw new Error('Insufficient bandwidth, used: ' + unsecured + ' max: ' +
+      throw new Errors.InsufficientLiquidityError('Insufficient bandwidth, used: ' +
+        unsecured + ' max: ' +
         this._bandwidth)
     }
 
     if (newPrepared.gt(util.xrpToDrops(account.getPaychan().amount))) {
-      throw new Error('Insufficient funds, have: ' +
+      throw new Errors.InsufficientLiquidityError('Insufficient funds, have: ' +
         util.xrpToDrops(account.getPaychan().amount) +
         ' need: ' + newPrepared.toString())
     }
@@ -490,7 +496,7 @@ class Plugin extends MiniAccountsPlugin {
         .equals(preparePacket.data.executionCondition)) {
           // TODO: could this leak data if the fulfillment is wrong in
           // a predictable way?
-        throw new Error(`condition and fulfillment don't match.
+        throw new Errors.WrongConditionError(`condition and fulfillment don't match.
             condition=${preparePacket.data.executionCondition.toString('hex')}
             fulfillment=${parsedResponse.data.fulfillment.toString('hex')}`)
       }

--- a/index.js
+++ b/index.js
@@ -442,8 +442,7 @@ class Plugin extends MiniAccountsPlugin {
     const { amount } = IlpPacket.deserializeIlpPrepare(ilpData)
 
     if (!account.getPaychan()) {
-      throw new Errors.UnreachableError(`Incoming traffic won't be accepted until a channel
-        to the connector is established.`)
+      throw new Errors.UnreachableError(`Incoming traffic won't be accepted until a channel to the connector is established.`)
     }
 
     if (account.isBlocked()) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1544,9 +1544,9 @@
       }
     },
     "ilp-plugin-mini-accounts": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/ilp-plugin-mini-accounts/-/ilp-plugin-mini-accounts-3.2.5.tgz",
-      "integrity": "sha512-ZRw/MDPe6teA2xE9z+QYwLxo6AUmGm1ipt1CMJ5CBgbxKp9Pa1f9eInVo//7CPKos/AeuxfHGux5glev/SwB/w==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/ilp-plugin-mini-accounts/-/ilp-plugin-mini-accounts-3.4.2.tgz",
+      "integrity": "sha512-Mk4qIoieJRYrFeb4vq/xtwCUqTTlGixa6EW7vIgEJ3NvsdF0Z3DY5YwY3S72DhGrDLm3e+53DU3tMHVJbON/0w==",
       "requires": {
         "base64url": "2.0.0",
         "btp-packet": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1092,6 +1092,11 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
+    "extensible-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/extensible-error/-/extensible-error-1.0.2.tgz",
+      "integrity": "sha512-kXU1FiTsGT8PyMKtFM074RK/VBpzwuQJicAHqBpsPDeTXBQiSALPjkjKXlyKdG/GP6lR7bBaEkq8qdoO2geu9g=="
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -1497,11 +1502,12 @@
       }
     },
     "ilp-packet": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-2.1.2.tgz",
-      "integrity": "sha1-VcvyCWQq35RM6iYT1Wlk/SvswAY=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-2.2.0.tgz",
+      "integrity": "sha1-qHJcwmMxxuLGU1OKEGPVUBQwXjE=",
       "requires": {
         "bignumber.js": "5.0.0",
+        "extensible-error": "1.0.2",
         "long": "3.2.0",
         "oer-utils": "1.3.4"
       },
@@ -1546,7 +1552,7 @@
         "btp-packet": "1.2.0",
         "debug": "3.1.0",
         "ilp": "11.4.0",
-        "ilp-packet": "2.1.2",
+        "ilp-packet": "2.2.0",
         "ilp-plugin-btp": "1.1.6",
         "ilp-plugin-payment-channel-framework": "1.3.5",
         "ilp-protocol-ildcp": "1.0.0",
@@ -1675,7 +1681,7 @@
       "resolved": "https://registry.npmjs.org/ilp-protocol-ildcp/-/ilp-protocol-ildcp-1.0.0.tgz",
       "integrity": "sha512-rmmrnwUKyVYHwJyteYMF6R6dO6ap1j6c7uNDiCqNLPXQSuNQUwAdXd+7CfStED/mOcM/D86IEZrcNx35GtCt6Q==",
       "requires": {
-        "ilp-packet": "2.1.2",
+        "ilp-packet": "2.2.0",
         "oer-utils": "1.3.4"
       }
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "btp-packet": "^1.2.0",
     "debug": "^3.1.0",
     "ilp-packet": "^2.2.0",
-    "ilp-plugin-mini-accounts": "^3.2.5",
+    "ilp-plugin-mini-accounts": "^3.4.2",
     "ilp-plugin-xrp-paychan-shared": "^1.0.0",
     "oer-utils": "^1.3.4",
     "ripple-address-codec": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "bignumber.js": "^6.0.0",
     "btp-packet": "^1.2.0",
     "debug": "^3.1.0",
-    "ilp-packet": "^2.1.2",
+    "ilp-packet": "^2.2.0",
     "ilp-plugin-mini-accounts": "^3.2.5",
     "ilp-plugin-xrp-paychan-shared": "^1.0.0",
     "oer-utils": "^1.3.4",


### PR DESCRIPTION
Uses new errors from ILP packet so that error codes propagate into the ILP reject. Also uses an ILP reject when there is an error processing an ILP packet instead of a BTP Error.

Closes https://github.com/interledgerjs/ilp-plugin-xrp-asym-server/issues/20