### PR TITLE
Feat: use channel watcher

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,15 @@ class Plugin extends MiniAccountsPlugin {
 
     this._channelToAccount = new Map()
     this._accounts = new Map()
+
+    this._watcher.on('channelClose', async (channelId, paychan) => {
+      try {
+        await this._channelClose(channelId)
+      } catch (e) {
+        console.error('ERROR: failed to close channel. channel=' + channelId +
+          ' error=' + e.stack)
+      }
+    })
   }
 
   xrpToBase (amount) {
@@ -332,6 +341,7 @@ class Plugin extends MiniAccountsPlugin {
       this._store.set('channel:' + channel, account.getAccount())
       account.setChannel(channel, paychan)
 
+      await this._watcher.watch(channel)
       await this._registerAutoClaim(account)
       debug('registered payment channel. account=', account.getAccount())
     }

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -114,6 +114,49 @@ describe('pluginSpec', () => {
     })
   })
 
+  describe('channel close', () => {
+    beforeEach(async function () {
+      this.from = 'test.example.35YywQ-3GYiO3MM4tvfaSGhty9NZELIBO3kmilL0Wak'
+      this.channelId = '45455C767516029F34E9A9CEDD8626E5D955964A041F6C9ACD11F9325D6164E0'
+      this.account = await this.plugin._getAccount(this.from)
+      this.plugin._channelToAccount.set(this.channelId, this.account)
+      await this.account.setClientChannel(this.channelId)
+      this.paychan = {
+        account: 'rPbVxek7Bovu4pWyCfGCVtgGbhwL6D55ot',
+        amount: '1',
+        balance: '0',
+        destination: 'r9Ggkrw4VCfRzSqgrkJTeyfZvBvaG9z3hg',
+        publicKey: 'EDD69138B8AB9B0471A734927FABE2B20D2943215C8EEEC61DC11598C79424414D',
+        settleDelay: 3600,
+        sourceTag: 1280434065,
+        previousAffectingTransactionID: '51F331B863D078CF5EFEF1FBFF2D0F4C4D12FD160272EEB03F572C904B800057',
+        previousAffectingTransactionLedgerVersion: 6089142
+      }
+    })
+
+    it('should call channelClose when close event is emitted', async function () {
+      const closeStub = this.sinon.stub(this.plugin, '_channelClose').resolves()
+      await this.plugin._watcher.emitAsync('channelClose', this.channelId, this.paychan)
+      assert.deepEqual(closeStub.firstCall.args, [ this.channelId ])
+    })
+
+    it('should submit the correct claim tx on channel close', async function () {
+      this.account.setBalance('1000')
+      const submitStub = this.sinon.stub(this.plugin, '_txSubmitter').resolves({
+        resultCode: 'tesSUCCESS'
+      })
+
+      await this.plugin._channelClose(this.channelId)
+
+      const [ method, args ] = submitStub.firstCall.args
+      assert.equal(method, 'preparePaymentChannelClaim')
+      assert.equal(args.balance, '0.001000')
+      assert.equal(args.publicKey, 'ED2E692BBF353D5EE420F86DF0A2AB0712758F8B4BA27EC46365DAA36CAE1CA4F1')
+      assert.equal(args.channel, this.channelId)
+      assert.equal(args.close, true)
+    })
+  })
+
   describe('handle custom data', () => {
     describe('channel protocol', () => {
       beforeEach(async function () {


### PR DESCRIPTION
The watcher was instantiated but wasn't used in previous versions. This isn't closing a critical vulnerability, but it makes sure that the server cleans up its outgoing payment channels when one of its clients closes their channel to the server.