### PR TITLE
Feat: support scale of 9

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ class Plugin extends MiniAccountsPlugin {
     this._claimInterval = opts.claimInterval || util.DEFAULT_CLAIM_INTERVAL
     this._store = new StoreWrapper(opts._store)
     this._txSubmitter = createSubmitter(this._api, this._address, this._secret)
-    this._currencyScale = opts.currencyScale || 6
+    this._currencyScale = (typeof opts.currencyScale === 'number') ? opts.currencyScale : 6
 
     this._channelToAccount = new Map()
     this._accounts = new Map()

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -412,6 +412,16 @@ describe('pluginSpec', () => {
           assert.deepEqual(encodeSpy.getCall(0).args, [ '2', this.channelId ])
         })
 
+        it('should scale up low-scale amount', async function () {
+          this.plugin._currencyScale = 2
+          const encodeSpy = this.sinon.spy(util, 'encodeClaim')
+          this.sinon.stub(this.plugin, '_call').resolves(null)
+
+          this.plugin._sendMoneyToAccount(100, this.from)
+
+          assert.deepEqual(encodeSpy.getCall(0).args, [ '10900000', this.channelId ])
+        })
+
         it('should keep error under a drop even on repeated roundings', async function () {
           const encodeSpy = this.sinon.spy(util, 'encodeClaim')
           this.sinon.stub(this.plugin, '_call').resolves(null)


### PR DESCRIPTION
Support a scale greater than that of XRP ledger. Amounts are simply rounded up in drops. Because the high-scale amounts are kept alongside claim signatures, though, the error is bounded at 1 drop. Uses the info at connection time to make sure the currency scale is matched with the client.