### PR TITLE
Fix: clean up nonexistant channel

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,8 @@ class Plugin extends MiniAccountsPlugin {
       account = new Account({
         account: accountName,
         store: this._store,
-        api: this._api
+        api: this._api,
+        scale: this._currencyScale
       })
       this._accounts.set(accountName, account)
     }
@@ -402,8 +403,8 @@ class Plugin extends MiniAccountsPlugin {
 
   async _autoClaim (account) {
     const lastClaimedAmount = account.getLastClaimedAmount()
-    const amount = this.baseToXrp(account.getIncomingClaim().amount)
-    const fee = await this._api.getFee()
+    const amount = account.getIncomingClaim().amount
+    const fee = this.xrpToBase(await this._api.getFee())
 
     debug('auto-claiming. account=' + account.getAccount(), 'amount=' + amount,
       'lastClaimedAmount=' + lastClaimedAmount, 'fee=' + fee)

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ class Plugin extends MiniAccountsPlugin {
 
   xrpToBase (amount) {
     return new BigNumber(amount)
-      .mul(Math.pow(10, this._currencyScale))
+      .times(Math.pow(10, this._currencyScale))
       .toString()
   }
 

--- a/src/account.js
+++ b/src/account.js
@@ -147,6 +147,8 @@ class Account {
   deleteChannel () {
     delete this._paychan
     delete this._lastClaimedAmount
+
+    this._store.delete(INCOMING_CLAIM(this._account))
     return this._store.delete(CHANNEL(this._account))
   }
 

--- a/src/account.js
+++ b/src/account.js
@@ -153,6 +153,13 @@ class Account {
   }
 
   deleteChannel () {
+    if (new BigNumber(this.getLastClaimedAmount()).lt(this.getIncomingClaim().amount)) {
+      console.error('Critical Error! Full balance was not able to be claimed before channel deletion.' +
+        ' claim=' + this._store.get(INCOMING_CLAIM(this._account)) +
+        ' lastClaimedAmount=' + this.getLastClaimedAmount() +
+        ' channelId=' + this._store.get(CHANNEL(this._account)))
+    }
+
     const newBalance = new BigNumber(this.getBalance())
       .minus(this.getLastClaimedAmount())
       .toString()

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -210,6 +210,21 @@ describe('pluginSpec', () => {
       assert.isTrue(spy.calledWith(this.channelId))
       assert.equal(this.plugin._channelToAccount.get(this.channelId).getAccount(), this.account)
     })
+
+    it('should delete persisted paychan if it does not exist on the ledger', async function () {
+      this.plugin._store.setCache(this.account + ':channel', this.channelId)
+      const stub = this.sinon.stub(this.plugin._api, 'getPaymentChannel').callsFake(async () => {
+        const error = new Error()
+        error.name = 'RippledError'
+        error.message = 'entryNotFound'
+        throw error
+      })
+
+      await this.plugin._connect(this.from, {})
+      assert.isTrue(stub.calledWith(this.channelId))
+      assert.isNotOk(this.plugin._channelToAccount.get(this.channelId))
+      assert.isNotOk(this.plugin._store.get(this.account + ':channel'))
+    })
   })
 
   describe('get extra info', () => {


### PR DESCRIPTION
Likely a cause of https://github.com/interledgerjs/ilp-connector/issues/427#issuecomment-383531025 . Before, if the channel didn't exist, the accounts class would do nothing, then the plugin would attempt to claim on the channel, throw an error, and that would skip over the channel delete code and cause the connect to fail.