### PR TITLE
Fix claims

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ class Plugin extends MiniAccountsPlugin {
         account: accountName,
         store: this._store,
         api: this._api,
-        scale: this._currencyScale
+        currencyScale: this._currencyScale
       })
       this._accounts.set(accountName, account)
     }

--- a/index.js
+++ b/index.js
@@ -143,7 +143,10 @@ class Plugin extends MiniAccountsPlugin {
   }
 
   async _channelClaim (account) {
-    debug('creating claim for claim. account=' + account.getAccount())
+    debug('creating claim for claim.' +
+      ' account=' + account.getAccount() +
+      ' channel=' + account.getChannel())
+
     const channel = account.getChannel()
     const claim = account.getIncomingClaim()
     const publicKey = account.getPaychan().publicKey
@@ -152,7 +155,7 @@ class Plugin extends MiniAccountsPlugin {
 
     try {
       await this._txSubmitter.submit('preparePaymentChannelClaim', {
-        balance: util.dropsToXrp(claim.amount.toString()),
+        balance: this.baseToXrp(claim.amount.toString()),
         signature: claim.signature.toUpperCase(),
         publicKey,
         channel

--- a/src/account.js
+++ b/src/account.js
@@ -56,7 +56,7 @@ class Account {
   }
 
   setLastClaimedAmount (amount) {
-    this._store.set(LAST_CLAIMED(this._account))
+    this._store.set(LAST_CLAIMED(this._account), amount)
   }
 
   isFunding () {

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -321,6 +321,18 @@ describe('pluginSpec', () => {
       }), 'unexpected args: ' + JSON.stringify(stub.args))
     })
 
+    it('should scale the claim amount appropriately', async function () {
+      this.plugin._currencyScale = 9
+      const stub = this.sinon.stub(this.plugin._txSubmitter, 'submit').resolves()
+      await this.plugin._channelClaim(this.account)
+      assert(stub.calledWithExactly('preparePaymentChannelClaim', {
+        balance: '0.000013',
+        signature: 'FOO',
+        publicKey: 'bar',
+        channel: '45455C767516029F34E9A9CEDD8626E5D955964A041F6C9ACD11F9325D6164E0'
+      }), 'unexpected args: ' + JSON.stringify(stub.args))
+    })
+
     it('should give an error if submit fails', async function () {
       const api = this.plugin._txSubmitter._api
       this.sinon.stub(api, 'preparePaymentChannelClaim').returns({ txJSON: 'xyz' })

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -346,6 +346,24 @@ describe('pluginSpec', () => {
         this.plugin._channelClaim(this.account),
         'Error submitting claim')
     })
+
+    it('should not auto claim when more has been claimed than the plugin thought', async function () {
+      this.plugin._api.getPaymentChannel = () => Promise.resolve({
+        account: 'rPbVxek7Bovu4pWyCfGCVtgGbhwL6D55ot',
+        amount: '1',
+        balance: '0.012345',
+        destination: 'r9Ggkrw4VCfRzSqgrkJTeyfZvBvaG9z3hg',
+        publicKey: 'EDD69138B8AB9B0471A734927FABE2B20D2943215C8EEEC61DC11598C79424414D',
+        settleDelay: 3600,
+        sourceTag: 1280434065,
+        previousAffectingTransactionID: '51F331B863D078CF5EFEF1FBFF2D0F4C4D12FD160272EEB03F572C904B800057',
+        previousAffectingTransactionLedgerVersion: 6089142
+      })
+
+      const stub = this.sinon.stub(this.plugin._txSubmitter, 'submit').resolves()
+      await this.plugin._channelClaim(this.account)
+      assert.isFalse(stub.called, 'claim should not have been submitted')
+    })
   })
 
   describe('handle money', () => {

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -231,6 +231,24 @@ describe('pluginSpec', () => {
       assert.equal(this.plugin._channelToAccount.get(this.channelId).getAccount(), this.account)
     })
 
+    it('should load lastClaimedAmount successfully', async function () {
+      this.plugin._api.getPaymentChannel = () => Promise.resolve({
+        account: 'rPbVxek7Bovu4pWyCfGCVtgGbhwL6D55ot',
+        amount: '1',
+        balance: '0.000050',
+        destination: 'r9Ggkrw4VCfRzSqgrkJTeyfZvBvaG9z3hg',
+        publicKey: 'EDD69138B8AB9B0471A734927FABE2B20D2943215C8EEEC61DC11598C79424414D',
+        settleDelay: 3600,
+        sourceTag: 1280434065,
+        previousAffectingTransactionID: '51F331B863D078CF5EFEF1FBFF2D0F4C4D12FD160272EEB03F572C904B800057',
+        previousAffectingTransactionLedgerVersion: 6089142
+      })
+
+      this.plugin._store.setCache(this.account + ':channel', this.channelId)
+      await this.plugin._connect(this.from, {})
+      assert.equal(this.plugin._channelToAccount.get(this.channelId).getLastClaimedAmount(), '50')
+    })
+
     it('should delete persisted paychan if it does not exist on the ledger', async function () {
       this.plugin._store.setCache(this.account + ':channel', this.channelId)
       const stub = this.sinon.stub(this.plugin._api, 'getPaymentChannel').callsFake(async () => {


### PR DESCRIPTION
- Fixes a bug which caused `lastClaimedAmount` to never be stored (causing claims to be submitted even when unnecessary)
- Fixes a bug which caused NaNs to crop up in the `lastClaimedAmount` (causing claims to be submitted when unnecessary)
- Adds a check before claims are submitted that checks the channel balance against the balace we're going to submit, to prevent `tecUNFUNDED` from coming up.