### PR TITLE
perf: cache incoming claims as object, not string

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -73,7 +73,7 @@ export default class Account {
   }
 
   getLastClaimedAmount (): string {
-    return this._store.get(LAST_CLAIMED(this._account)) || '0'
+    return this._store.getString(LAST_CLAIMED(this._account)) || '0'
   }
 
   setLastClaimedAmount (amount: string) {
@@ -90,13 +90,13 @@ export default class Account {
 
   async connect () {
     await Promise.all([
-      this._store.load(BALANCE(this._account)),
-      this._store.load(INCOMING_CLAIM(this._account)),
-      this._store.load(CHANNEL(this._account)),
-      this._store.load(IS_BLOCKED(this._account)),
-      this._store.load(CLIENT_CHANNEL(this._account)),
-      this._store.load(OUTGOING_BALANCE(this._account)),
-      this._store.load(LAST_CLAIMED(this._account))
+      this._store.loadString(BALANCE(this._account)),
+      this._store.loadObject(INCOMING_CLAIM(this._account)),
+      this._store.loadString(CHANNEL(this._account)),
+      this._store.loadString(IS_BLOCKED(this._account)),
+      this._store.loadString(CLIENT_CHANNEL(this._account)),
+      this._store.loadString(OUTGOING_BALANCE(this._account)),
+      this._store.loadString(LAST_CLAIMED(this._account))
     ])
 
     const channelId = this.getChannel()
@@ -131,13 +131,13 @@ export default class Account {
   }
 
   getBalance () {
-    return new BigNumber(this._store.get(BALANCE(this._account)) || '0')
+    return new BigNumber(this._store.getString(BALANCE(this._account)) || '0')
   }
 
   getIncomingClaim (): Claim {
     const paychanAmount = new BigNumber(this.getLastClaimedAmount())
-    const storedClaim = JSON.parse(this._store.get(INCOMING_CLAIM(this._account)) ||
-      '{"amount":"0"}')
+    const storedClaim = this._store.getObject(INCOMING_CLAIM(this._account)) as Claim ||
+      { amount: '0' }
 
     if (paychanAmount.gt(storedClaim.amount)) {
       return { amount: paychanAmount.toString() }
@@ -147,19 +147,19 @@ export default class Account {
   }
 
   getChannel () {
-    return this._store.get(CHANNEL(this._account))
+    return this._store.getString(CHANNEL(this._account))
   }
 
   isBlocked () {
-    return this._store.get(IS_BLOCKED(this._account)) === 'true'
+    return this._store.getString(IS_BLOCKED(this._account)) === 'true'
   }
 
   getClientChannel () {
-    return this._store.get(CLIENT_CHANNEL(this._account))
+    return this._store.getString(CLIENT_CHANNEL(this._account))
   }
 
   getOutgoingBalance () {
-    return new BigNumber(this._store.get(OUTGOING_BALANCE(this._account)) || '0')
+    return new BigNumber(this._store.getString(OUTGOING_BALANCE(this._account)) || '0')
   }
 
   setBalance (balance: string) {
@@ -167,7 +167,7 @@ export default class Account {
   }
 
   setIncomingClaim (incomingClaim: Claim) {
-    return this._store.set(INCOMING_CLAIM(this._account), JSON.stringify(incomingClaim))
+    return this._store.set(INCOMING_CLAIM(this._account), incomingClaim)
   }
 
   setChannel (channel: string, paychan: Paychan) {
@@ -179,9 +179,9 @@ export default class Account {
   deleteChannel () {
     if (new BigNumber(this.getLastClaimedAmount()).lt(this.getIncomingClaim().amount)) {
       this._log.error('Critical Error! Full balance was not able to be claimed before channel deletion.' +
-        ' claim=' + this._store.get(INCOMING_CLAIM(this._account)) +
+        ' claim=' + JSON.stringify(this._store.getObject(INCOMING_CLAIM(this._account))) +
         ' lastClaimedAmount=' + this.getLastClaimedAmount() +
-        ' channelId=' + this._store.get(CHANNEL(this._account)))
+        ' channelId=' + this._store.getString(CHANNEL(this._account)))
     }
 
     const newBalance = new BigNumber(this.getBalance())

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,7 +198,6 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
     }
   }
 
-
   async _channelClaim (account: Account, close: boolean = false) {
     this._log.trace('creating claim for claim.' +
       ' account=' + account.getAccount() +
@@ -381,8 +380,8 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
       const paychan = await this._api.getPaymentChannel(channel)
 
       // TODO: factor reverse-channel lookup into other class?
-      await this._store.load('channel:' + channel)
-      const accountForChannel = this._store.get('channel:' + channel)
+      await this._store.loadString('channel:' + channel)
+      const accountForChannel = this._store.getString('channel:' + channel)
       if (accountForChannel && account.getAccount() !== accountForChannel) {
         throw new Error(`this channel has already been associated with a ` +
           `different account. account=${account.getAccount()} associated=${accountForChannel}`)

--- a/src/store-wrapper.ts
+++ b/src/store-wrapper.ts
@@ -2,7 +2,7 @@ import { Store } from './util'
 
 export default class StoreWrapper {
   private _store?: Store
-  private _cache: Map<string, string | void>
+  private _cache: Map<string, string | void | object>
   private _write: Promise<void>
 
   constructor (store: Store) {
@@ -11,13 +11,18 @@ export default class StoreWrapper {
     this._write = Promise.resolve()
   }
 
-  async load (key: string) {
+  async loadString (key: string) { return this._load(key, false) }
+  async loadObject (key: string) { return this._load(key, true) }
+
+  private async _load (key: string, parse: boolean) {
     if (!this._store) return
     if (this._cache.has(key)) return
     const value = await this._store.get(key)
 
     // once the call to the store returns, double-check that the cache is still empty.
-    if (!this._cache.has(key)) this._cache.set(key, value)
+    if (!this._cache.has(key)) {
+      this._cache.set(key, (parse && value) ? JSON.parse(value) : value)
+    }
   }
 
   unload (key: string) {
@@ -26,15 +31,24 @@ export default class StoreWrapper {
     }
   }
 
-  get (key: string): string | void {
-    return this._cache.get(key)
+  getString (key: string): string | void {
+    const val = this._cache.get(key)
+    if (val === undefined || typeof val === 'string') return val
+    throw new Error('StoreWrapper#getString: unexpected type for key=' + key)
   }
 
-  set (key: string, value: string) {
+  getObject (key: string): object | void {
+    const val = this._cache.get(key)
+    if (val === undefined || typeof val === 'object') return val
+    throw new Error('StoreWrapper#getObject: unexpected type for key=' + key)
+  }
+
+  set (key: string, value: string | object) {
     this._cache.set(key, value)
+    const valueStr = typeof value === 'object' ? JSON.stringify(value) : value
     this._write = this._write.then(() => {
       if (this._store) {
-        return this._store.put(key, value)
+        return this._store.put(key, valueStr)
       }
     })
   }

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -266,8 +266,8 @@ describe('pluginSpec', () => {
       await this.plugin._connect(this.from, {})
       assert.isTrue(stub.calledWith(this.channelId))
       assert.isNotOk(this.plugin._channelToAccount.get(this.channelId))
-      assert.isNotOk(this.plugin._store.get(this.account + ':channel'))
-      assert.isNotOk(this.plugin._store.get(this.account + ':last_claimed'))
+      assert.isNotOk(this.plugin._store.getString(this.account + ':channel'))
+      assert.isNotOk(this.plugin._store.getString(this.account + ':last_claimed'))
     })
   })
 
@@ -308,10 +308,10 @@ describe('pluginSpec', () => {
       this.channelId = '45455C767516029F34E9A9CEDD8626E5D955964A041F6C9ACD11F9325D6164E0'
       this.account = await this.plugin._getAccount(this.from)
       this.plugin._store.setCache(this.account.getAccount() + ':channel', this.channelId)
-      this.plugin._store.setCache(this.account.getAccount() + ':claim', JSON.stringify({
+      this.plugin._store.setCache(this.account.getAccount() + ':claim', {
         amount: '12345',
         signature: 'foo'
-      }))
+      })
       this.account._paychan = { publicKey: 'bar', balance: '0' }
     })
 
@@ -379,10 +379,10 @@ describe('pluginSpec', () => {
       this.channelId = '45455C767516029F34E9A9CEDD8626E5D955964A041F6C9ACD11F9325D6164E0'
       this.account = await this.plugin._getAccount(this.from)
       this.plugin._store.setCache(this.account.getAccount() + ':channel', this.channelId)
-      this.plugin._store.setCache(this.account.getAccount() + ':claim', JSON.stringify({
+      this.plugin._store.setCache(this.account.getAccount() + ':claim', {
         amount: '12345',
         signature: 'foo'
-      }))
+      })
       this.account._paychan = {
         account: 'rPbVxek7Bovu4pWyCfGCVtgGbhwL6D55ot',
         amount: '1',
@@ -479,10 +479,10 @@ describe('pluginSpec', () => {
       this.account = await this.plugin._getAccount(this.from)
       this.plugin._store.setCache(this.account.getAccount() + ':channel', this.channelId)
       this.plugin._store.setCache(this.account.getAccount() + ':client_channel', this.channelId)
-      this.plugin._store.setCache(this.account.getAccount() + ':claim', JSON.stringify({
+      this.plugin._store.setCache(this.account.getAccount() + ':claim', {
         amount: '12345',
         signature: 'foo'
-      }))
+      })
       this.plugin._store.setCache(this.account.getAccount() + ':outgoing_balance', '12345')
       this.claim = {
         amount: '12345',
@@ -521,7 +521,7 @@ describe('pluginSpec', () => {
 
           this.plugin._keyPair = {}
           this.plugin._funding = true
-          this.plugin._store.setCache(this.account.getAccount() + ':outgoing_balance', 990)
+          this.plugin._store.setCache(this.account.getAccount() + ':outgoing_balance', '990')
         })
 
         it('should round high-scale amount up to next drop', async function () {
@@ -623,10 +623,10 @@ describe('pluginSpec', () => {
       this.channelId = '45455C767516029F34E9A9CEDD8626E5D955964A041F6C9ACD11F9325D6164E0'
       this.account = await this.plugin._getAccount(this.from)
       this.plugin._store.setCache(this.account.getAccount() + ':channel', this.channelId)
-      this.plugin._store.setCache(this.account.getAccount() + ':claim', JSON.stringify({
+      this.plugin._store.setCache(this.account.getAccount() + ':claim', {
         amount: '12345',
         signature: 'foo'
-      }))
+      })
       this.account._paychan = {
         account: 'rPbVxek7Bovu4pWyCfGCVtgGbhwL6D55ot',
         amount: '1',
@@ -751,10 +751,10 @@ describe('pluginSpec', () => {
       this.account = await this.plugin._getAccount(this.from)
       this.plugin._store.setCache(this.account.getAccount() + ':channel', this.channelId)
       this.plugin._store.setCache(this.account.getAccount() + ':last_claimed', '12300')
-      this.plugin._store.setCache(this.account.getAccount() + ':claim', JSON.stringify({
+      this.plugin._store.setCache(this.account.getAccount() + ':claim', {
         amount: '13901',
         signature: 'foo'
-      }))
+      })
       this.account._paychan = {
         account: 'rPbVxek7Bovu4pWyCfGCVtgGbhwL6D55ot',
         amount: '1',
@@ -788,10 +788,10 @@ describe('pluginSpec', () => {
       beforeEach(function () {
         this.plugin._currencyScale = 9
         this.plugin._store.setCache(this.account.getAccount() + ':last_claimed', '12300000')
-        this.plugin._store.setCache(this.account.getAccount() + ':claim', JSON.stringify({
+        this.plugin._store.setCache(this.account.getAccount() + ':claim', {
           amount: '13901000',
           signature: 'foo'
-        }))
+        })
       })
 
       it('should auto claim when amount is more than 100 * fee + last claim', async function () {
@@ -818,10 +818,10 @@ describe('pluginSpec', () => {
       this.channelId = '45455C767516029F34E9A9CEDD8626E5D955964A041F6C9ACD11F9325D6164E0'
       this.account = await this.plugin._getAccount(this.from)
       this.plugin._store.setCache(this.account.getAccount() + ':channel', this.channelId)
-      this.plugin._store.setCache(this.account.getAccount() + ':claim', JSON.stringify({
+      this.plugin._store.setCache(this.account.getAccount() + ':claim', {
         amount: '12345',
         signature: 'foo'
-      }))
+      })
       this.account._paychan = {
         account: 'rPbVxek7Bovu4pWyCfGCVtgGbhwL6D55ot',
         amount: '1',


### PR DESCRIPTION
This saves the Account from repeatedly serializing and deserializing cached claim objects.