### PR TITLE
Feat: add connection states

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -39,6 +39,20 @@ export enum ReadyState {
   BLOCKED = 8
 }
 
+function stateToString (state: ReadyState): string {
+  switch (state) {
+    case ReadyState.INITIAL: return 'INITIAL'
+    case ReadyState.LOADING_CHANNEL: return 'LOADING_CHANNEL'
+    case ReadyState.ESTABLISHING_CHANNEL: return 'ESTABLISHING_CHANNEL'
+    case ReadyState.PREPARING_CHANNEL: return 'PREPARING_CHANNEL'
+    case ReadyState.LOADING_CLIENT_CHANNEL: return 'LOADING_CLIENT_CHANNEL'
+    case ReadyState.ESTABLISHING_CLIENT_CHANNEL: return 'ESTABLISHING_CLIENT_CHANNEL'
+    case ReadyState.PREPARING_CLIENT_CHANNEL: return 'PREPARING_CLIENT_CHANNEL'
+    case ReadyState.READY: return 'READY'
+    case ReadyState.BLOCKED: return 'BLOCKED'
+  }
+}
+
 export class Account {
   private _store: StoreWrapper
   private _account: string
@@ -334,10 +348,14 @@ export class Account {
     return this._state
   }
 
+  getStateString () {
+    return stateToString(this._state)
+  }
+
   _assertState (state: ReadyState) {
     if (this._state !== state) {
-      throw new Error(`account must be in state ${state}.` +
-        ' state=' + this.getState() +
+      throw new Error(`account must be in state ${stateToString(state)}.` +
+        ' state=' + this.getStateString() +
         ' account=' + this.getAccount())
     }
   }

--- a/src/account.ts
+++ b/src/account.ts
@@ -178,6 +178,7 @@ export class Account {
     if (clientChannelId) {
       try {
         this._clientPaychan = await this._api.getPaymentChannel(clientChannelId) as Paychan
+        this._state = ReadyState.READY
       } catch (e) {
         this._log.error('failed to load client channel entry. error=' + e.message)
         if (e.name === 'RippledError' && e.message === 'entryNotFound') {

--- a/src/account.ts
+++ b/src/account.ts
@@ -143,7 +143,7 @@ export class Account {
   async _connectChannel (): Promise<void> {
     this._assertState(ReadyState.LOADING_CHANNEL)
 
-    const channelId = this.getChannel()
+    const channelId = this._store.get(CHANNEL(this._account))
     if (channelId) {
       try {
         const paychan = await this._api.getPaymentChannel(channelId) as Paychan
@@ -174,7 +174,7 @@ export class Account {
   async _connectClientChannel (): Promise<void> {
     this._assertState(ReadyState.LOADING_CLIENT_CHANNEL)
 
-    const clientChannelId = this.getClientChannel()
+    const clientChannelId = this._store.get(CLIENT_CHANNEL(this._account))
     if (clientChannelId) {
       try {
         this._clientPaychan = await this._api.getPaymentChannel(clientChannelId) as Paychan
@@ -268,7 +268,7 @@ export class Account {
     this._state = ReadyState.ESTABLISHING_CHANNEL
   }
 
-  setChannel (channel: string, paychan: Paychan) {
+  async setChannel (channel: string, paychan: Paychan) {
     this._assertState(ReadyState.PREPARING_CHANNEL)
     this._paychan = paychan
     this.setLastClaimedAmount(this.xrpToBase(paychan.balance))
@@ -323,7 +323,7 @@ export class Account {
   }
 
   setClientChannel (clientChannel: string, clientPaychan: Paychan) {
-    this._assertState(ReadyState.ESTABLISHING_CLIENT_CHANNEL)
+    this._assertState(ReadyState.PREPARING_CLIENT_CHANNEL)
 
     this._clientPaychan = clientPaychan
     this._store.set(CLIENT_CHANNEL(this._account), clientChannel)

--- a/src/index.ts
+++ b/src/index.ts
@@ -403,7 +403,7 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
     if (channelProtocol) {
       if (!account.isReady() && account.getState() !== ReadyState.ESTABLISHING_CHANNEL) {
         throw new Error('channel protocol can only be used in READY and ESTABLISHING_CHANNEL states.' +
-          ' state=' + account.getState())
+          ' state=' + account.getStateString())
       }
 
       this._log.trace('got message for incoming channel. account=', account.getAccount())
@@ -480,7 +480,7 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
     if (fundChannel) {
       if (account.getState() !== ReadyState.ESTABLISHING_CLIENT_CHANNEL) {
         throw new Error('fund protocol can only be used in ESTABLISHING_CLIENT_CHANNEL state.' +
-          ' state=' + account.getState())
+          ' state=' + account.getStateString())
       }
 
       if (new BigNumber(util.xrpToDrops(account.getPaychan().amount)).lt(MIN_INCOMING_CHANNEL)) {
@@ -613,7 +613,7 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
 
     if (!account.isReady()) {
       throw new Error('ilp packets will only be forwarded in READY state.' +
-        ' state=' + account.getState())
+        ' state=' + account.getStateString())
     }
 
     if (this._maxPacketAmount.isLessThan(amount)) {
@@ -660,7 +660,7 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
     const account = this._getAccount(destination)
     if (!account.isReady()) {
       throw new Error('account must be in READY state to receive packets.' +
-        ' state=' + account.getState())
+        ' state=' + account.getStateString())
     }
   }
 
@@ -715,7 +715,7 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
     if (!account.isReady()) {
       this._log.error('tried to send settlement to account which is not connected.' +
         ' account=' + account.getAccount() +
-        ' state=' + account.getState() +
+        ' state=' + account.getStateString() +
         ' transferAmount=' + transferAmount)
       throw new Error('account is not initialized. account=' + account.getAccount())
     }
@@ -855,7 +855,7 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
     if (account.getState() < ReadyState.LOADING_CLIENT_CHANNEL) {
       this._log.error('got claim from account which is not fully connected.' +
         ' account=' + account.getAccount() +
-        ' state=' + account.getState())
+        ' state=' + account.getStateString())
       throw new Error('account is not initialized; claim cannot be accepted.' +
         ' account=' + account.getAccount())
     }

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -148,7 +148,7 @@ describe('pluginSpec', () => {
         previousAffectingTransactionLedgerVersion: 6089142
       }
       this.account._state = ReadyState.PREPARING_CHANNEL
-      this.account.setChannel(this.channelId, this.paychan)
+      await this.account.setChannel(this.channelId, this.paychan)
       this.account._state = ReadyState.PREPARING_CLIENT_CHANNEL
       await this.account.setClientChannel(this.channelId, {})
       this.account.setIncomingClaim({
@@ -197,7 +197,7 @@ describe('pluginSpec', () => {
           previousAffectingTransactionLedgerVersion: 6089142
         }
         this.account._state = ReadyState.PREPARING_CHANNEL
-        this.account.setChannel(this.channelId, this.paychan)
+        await this.account.setChannel(this.channelId, this.paychan)
         this.plugin._channelToAccount.set(this.channelId, this.account)
         this.account._state = ReadyState.READY
         this.channelSig = '9F878049FBBF4CEBAB29E6D840984D777C10ECE0FB96B0A56FF2CBC90D38DD03571A7D95A7721173970D39E1FC8AE694D777F5363AA37950D91F9B4B7E179C00'


### PR DESCRIPTION
This PR adds a new field to the `Account` object, called `_state`. This keeps track of where the account is in the channel establishment and initialization process. The plugin class closely watches this property in order to make sure that state transitions only happen when it's appropriate. It also blocks packets to/from any account which is not fully `READY`.

State transitions go as follows:

- The account is constructed and starts in `INITIAL`.
- `.connect()` is called, and fields are loaded from the store. The state is set to `LOADING_CHANNEL` `._connectChannel` is called.
- `._connectChannel` tries to load the channel details from the store, and then loads up-to-date details from the XRP ledger.
  - If the ledger call times out it will retry after 2 seconds.
  - If the ledger calls says that the channel has been deleted, then the account is put into the `BLOCKED` state.
  - If all details are loaded correctly the state is set to `LOADING_CLIENT_CHANNEL` and `._connectClientChannel` is called.
  - If no channel exists, the channel is placed into the `ESTABLISHING_CHANNEL` state, where it waits until a `channel` BTP message comes in.
- `.connectClientChannel` tries to load the client channel (the server->client channel) details from the store, and then loads up-to-date details from the XRP ledger.
  - If the ledger call times out it will retry after 2 seconds.
  - If the ledger calls says that the client channel has been deleted, then the account is put into the `BLOCKED` state.
  - If all details are loaded correctly the state is set to `READY`, and initialization is complete.
  - If no client channel exists, the channel is placed into the `ESTABLISHING_CLIENT_CHANNEL` state, where it waits until a `fund_channel` BTP message comes in.

- If the account is in the `ESTABLISHING_CHANNEL` state and a `channel` BTP message comes in, it will set the state to `PREPARING_CHANNEL`. It asynchronously validates channel details.
  - If validation succeeds it moves into the `LOADING_CLIENT_CHANNEL` state. It then calls `.connectClientChannel`.
  - If validation fails, it moves back into the `ESTABLISHING_CHANNEL` state.

- If the account is in the `ESTABLISHING_CLIENT_CHANNEL` state and a `fund_channel` BTP message comes in, it will set the state to `PREPARING_CLIENT_CHANNEL`. It asynchronously creates a channel to the client.
  - If the transaction succeeds it moves into the `READY` state.
  - If the transaction fails it moves into the `ESTABLISHING_CLIENT_CHANNEL` state.

I'm going to continue adding more tests against this behavior, because it's a pretty big change to a very important module.