### PR TITLE
Feat: save the reason an account was blocked

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -269,7 +269,7 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
     }
 
     // disable the account once the channel is closing
-    account.block()
+    account.block(true, 'channel is closing/closed. channelId=' + channelId)
     await this._channelClaim(account, true)
   }
 
@@ -292,7 +292,8 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
 
     if (account.isBlocked()) {
       throw new Error('cannot connect to blocked account. ' +
-        'reconfigure your uplink to connect with a new payment channel.')
+        'reconfigure your uplink to connect with a new payment channel.' +
+        ' reason=' + account.getBlockReason())
     }
 
     if (account.getState() > ReadyState.PREPARING_CHANNEL) {
@@ -313,7 +314,9 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
           this._log.error('could not delete channel. error=', err)
         }
         this._log.trace('blocking account. account=' + account.getAccount())
-        account.block()
+        account.block(true, 'failed to validate channel.' +
+          ' channelId=' + account.getChannel() +
+          ' error=' + e.message)
       }
     }
 

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -249,6 +249,15 @@ describe('pluginSpec', () => {
       assert.isTrue(spy.calledWith(this.account + ':channel'))
     })
 
+    it('should reject and give block reason if account blocked', async function () {
+      const account = await this.plugin._getAccount(this.from)
+      await account.connect()
+      account.block(true, 'blocked for a reason')
+
+      await assert.isRejected(this.plugin._connect(this.from, {}),
+        /cannot connect to blocked account. reconfigure your uplink to connect with a new payment channel. reason=blocked for a reason/)
+    })
+
     it('should load details for existing paychan', async function () {
       const spy = this.sinon.spy(this.plugin._api, 'getPaymentChannel')
       this.plugin._store.setCache(this.account + ':channel', this.channelId)
@@ -996,6 +1005,7 @@ describe('pluginSpec', () => {
       this.account._store.setCache(this.account.getAccount() + ':block', 'true')
       await this.account.connect()
       assert.equal(this.account.getStateString(), 'BLOCKED')
+      assert.equal(this.account.getBlockReason(), 'channel must be re-established')
     })
 
     it('should set to ESTABLISHING_CHANNEL if no channel exists', async function () {


### PR DESCRIPTION
The error code that you get when your account is blocked can be confusing. It could be for several reasons:

- your channel (client -> connector) didn't exist
- the client channel (connector -> client) didn't exist
- your channel was in a closing state
- your channel had some invalid fields in it

although the solution is usually to create a new channel, this should help us diagnose the issue that's going on. The error is returned only on `_connect` calls that error out, because if we returned this on blocked packets it could expose details to untrusted parties. We may want to return a version of the error with some details obscured, though, if this error message is too hard to find.