### PR TITLE
Feat: load outgoing balance from client paychan balance

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -182,6 +182,10 @@ export class Account {
     if (clientChannelId) {
       try {
         this._clientPaychan = await this._api.getPaymentChannel(clientChannelId) as Paychan
+        if (this.getOutgoingBalance().lt(this.xrpToBase(this._clientPaychan.balance))) {
+          this.setOutgoingBalance(this.xrpToBase(this._clientPaychan.balance))
+        }
+
         this._state = ReadyState.READY
       } catch (e) {
         this._log.error('failed to load client channel entry. error=' + e.message)
@@ -351,6 +355,10 @@ export class Account {
     this._assertState(ReadyState.PREPARING_CLIENT_CHANNEL)
 
     this._clientPaychan = clientPaychan
+    if (this.getOutgoingBalance().lt(this.xrpToBase(this._clientPaychan.balance))) {
+      this.setOutgoingBalance(this.xrpToBase(this._clientPaychan.balance))
+    }
+
     this._store.set(CLIENT_CHANNEL(this._account), clientChannel)
     this._state = ReadyState.READY
   }


### PR DESCRIPTION
When connecting an account, the asym-server now makes sure that it signs claims starting at the maximum of the last outgoing claim it signed and the channel's balance. This prevents a case from occurring where the asym-server loses its most recent claim and becomes permanently unable to settle to its children.