### PR TITLE
refactor: redundant code in _handlePrepareResponse

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 'use strict'
 
-import * as crypto from 'crypto'
 import * as IlpPacket from 'ilp-packet'
 
 const { Errors } = IlpPacket

--- a/src/index.ts
+++ b/src/index.ts
@@ -672,17 +672,6 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
 
   _handlePrepareResponse (destination: string, parsedResponse: IlpPacket.IlpPacket, preparePacket: IlpPacket.IlpPacket) {
     this._log.trace('got prepare response', parsedResponse)
-    if (parsedResponse.type === IlpPacket.Type.TYPE_ILP_FULFILL) {
-      if (!crypto.createHash('sha256')
-        .update(parsedResponse.data.fulfillment)
-        .digest()
-        .equals(preparePacket.data.executionCondition)) {
-        // TODO: could this leak data if the fulfillment is wrong in
-        // a predictable way?
-        throw new Errors.WrongConditionError(`condition and fulfillment don't match.
-            condition=${preparePacket.data.executionCondition.toString('hex')}
-            fulfillment=${parsedResponse.data.fulfillment.toString('hex')}`)
-      }
 
       if (preparePacket.data.amount === '0') {
         this._log.trace('validated fulfillment for zero-amount packet, not settling.')

--- a/src/index.ts
+++ b/src/index.ts
@@ -672,7 +672,7 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
 
   _handlePrepareResponse (destination: string, parsedResponse: IlpPacket.IlpPacket, preparePacket: IlpPacket.IlpPacket) {
     this._log.trace('got prepare response', parsedResponse)
-
+    if (parsedResponse.type === IlpPacket.Type.TYPE_ILP_FULFILL) {
       if (preparePacket.data.amount === '0') {
         this._log.trace('validated fulfillment for zero-amount packet, not settling.')
         return

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -1085,34 +1085,6 @@ describe('pluginSpec', () => {
       assert.isFalse(stub.called)
     })
 
-    it('should handle a prepare response (invalid fulfill)', async function () {
-      const stub = this.sinon.stub(this.plugin, '_call')
-        .returns(Promise.resolve())
-
-      this.fulfill.data.fulfillment = Buffer.from('garbage')
-      assert.throws(
-        () => this.plugin._handlePrepareResponse(this.from, this.fulfill, this.prepare),
-        IlpPacket.Errors.WrongConditionError,
-        'condition and fulfillment don\'t match.')
-
-      await new Promise(resolve => setTimeout(resolve, 10))
-      assert.isFalse(stub.called)
-    })
-
-    it('should handle a prepare response (no channel to client)', async function () {
-      const stub = this.sinon.stub(this.plugin, '_call')
-        .returns(Promise.resolve())
-
-      this.fulfill.data.fulfillment = Buffer.from('garbage')
-      assert.throws(
-        () => this.plugin._handlePrepareResponse(this.from, this.fulfill, this.prepare),
-        IlpPacket.Errors.WrongConditionError,
-        'condition and fulfillment don\'t match.')
-
-      await new Promise(resolve => setTimeout(resolve, 10))
-      assert.isFalse(stub.called)
-    })
-
     it('should increase owed amount when settle fails', async function () {
       const stub = this.sinon.stub(this.plugin, '_call')
         .returns(Promise.resolve())


### PR DESCRIPTION
The code to match the hash of the preimage against the execution
condition from the prepare is redundant. Mini-accounts checks this in
sendData, which is the only place that _handlePrepareResponse is
called.