### PR TITLE
Feat: admin interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1014,7 +1014,7 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
 
     switch (cmd.command) {
       case 'settle':
-        const amount = this.baseToXrp(cmd.amount || '0')
+        const amount = this.xrpToBase(cmd.amount || '0')
         const requestId = await util._requestId()
         const destination = this._prefix + account.getAccount()
         await this._call(destination, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,17 @@ export interface ExtraInfo {
   clientChannel?: string
 }
 
+export enum AdminCommandName {
+  BLOCK = 'block',
+  SETTLE = 'settle'
+}
+
+export interface AdminCommand {
+  command: AdminCommandName,
+  account: string,
+  amount?: string
+}
+
 export interface IlpPluginAsymServerOpts {
   assetScale?: number
   currencyScale?: number
@@ -966,5 +977,66 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
     this._api.connection.removeAllListeners()
     await this._api.disconnect()
     await this._store.close()
+  }
+
+  async getAdminInfo () {
+    const accountInfo = await this._api.getAccountInfo(this._address)
+    const serverInfo = await this._api.getServerInfo()
+    const reserved = Number(accountInfo.ownerCount) *
+      Number(serverInfo.validatedLedger.reserveIncrementXRP)
+
+    return {
+      xrpAddress: this._address,
+      xrpBalance: {
+        total: accountInfo.xrpBalance,
+        reserved: String(reserved),
+        available: String(Number(accountInfo.xrpBalance) - reserved)
+      },
+      clients: Array.from(this._accounts.values()).map(account => {
+        return {
+          account: account.getAccount(),
+          xrpAddress: account.getPaychan().account,
+          channel: account.getChannel(),
+          channelBalance: account.getPaychan().balance,
+          clientChannel: account.getClientChannel(),
+          clientChannelBalance: this.baseToXrp(account.getOutgoingBalance()),
+          state: account.getStateString()
+        }
+      })
+    }
+  }
+
+  async sendAdminInfo (cmd: AdminCommand) {
+    const account = this._accounts.get(cmd.account)
+    if (!account) {
+      throw new Error('no account by that name. account=' + account)
+    }
+
+    switch (cmd.command) {
+      case 'settle':
+        const amount = this.baseToXrp(cmd.amount || '0')
+        const requestId = await util._requestId()
+        const destination = this._prefix + account.getAccount()
+        await this._call(destination, {
+          type: BtpPacket.TYPE_TRANSFER,
+          requestId,
+          data: {
+            amount,
+            protocolData: this._sendMoneyToAccount(
+              amount,
+              destination)
+          }
+        })
+        break
+
+      case 'block':
+        account.block()
+        break
+
+      default:
+        throw Error('unknown command')
+    }
+
+    return {}
   }
 }

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -1246,4 +1246,97 @@ describe('pluginSpec', () => {
       assert.equal(this.account.getStateString(), 'READY')
     })
   })
+
+  describe('admin interface', function () {
+    beforeEach(async function () {
+      this.sinon.stub(this.plugin._api, 'getAccountInfo')
+        .resolves({
+          xrpBalance: '10000',
+          ownerCount: '200'
+        })
+
+      this.sinon.stub(this.plugin._api, 'getServerInfo')
+        .resolves({
+          validatedLedger: {
+            reserveIncrementXRP: '4'
+          }
+        })
+
+      this.from = 'test.example.35YywQ-3GYiO3MM4tvfaSGhty9NZELIBO3kmilL0Wak'
+      this.channelId = '45455C767516029F34E9A9CEDD8626E5D955964A041F6C9ACD11F9325D6164E0'
+      this.account = await this.plugin._getAccount(this.from)
+      this.account._state = ReadyState.READY
+      this.plugin._store.setCache(this.account.getAccount() + ':client_channel', this.channelId)
+      this.plugin._store.setCache(this.account.getAccount() + ':channel', this.channelId)
+      this.plugin._store.setCache(this.account.getAccount() + ':claim', {
+        amount: '12345',
+        signature: 'foo'
+      })
+      this.account._paychan = this.account._clientPaychan = {
+        account: 'rPbVxek7Bovu4pWyCfGCVtgGbhwL6D55ot',
+        amount: '1',
+        balance: '0',
+        destination: 'r9Ggkrw4VCfRzSqgrkJTeyfZvBvaG9z3hg',
+        publicKey: 'EDD69138B8AB9B0471A734927FABE2B20D2943215C8EEEC61DC11598C79424414D',
+        settleDelay: 3600,
+        sourceTag: 1280434065,
+        previousAffectingTransactionID: '51F331B863D078CF5EFEF1FBFF2D0F4C4D12FD160272EEB03F572C904B800057',
+        previousAffectingTransactionLedgerVersion: 6089142
+      }
+    })
+
+    it('should get admin info', async function () {
+      assert.deepEqual(await this.plugin.getAdminInfo(), {
+        clients: [{
+          account: '35YywQ-3GYiO3MM4tvfaSGhty9NZELIBO3kmilL0Wak',
+          channel: '45455C767516029F34E9A9CEDD8626E5D955964A041F6C9ACD11F9325D6164E0',
+          channelBalance: '0',
+          clientChannel: '45455C767516029F34E9A9CEDD8626E5D955964A041F6C9ACD11F9325D6164E0',
+          clientChannelBalance: '0.000000',
+          state: 'READY',
+          xrpAddress: 'rPbVxek7Bovu4pWyCfGCVtgGbhwL6D55ot'
+        }],
+        xrpAddress: 'r9Ggkrw4VCfRzSqgrkJTeyfZvBvaG9z3hg',
+        xrpBalance: {
+          'available': '9200',
+          'reserved': '800',
+          'total': '10000'
+        }
+      })
+    })
+
+    it('should apply a "settle" command', async function () {
+      const idStub = this.sinon.stub(util, '_requestId').resolves(12345)
+      const callStub = this.sinon.stub(this.plugin, '_call').resolves(null)
+      const sendStub = this.sinon.stub(this.plugin, '_sendMoneyToAccount')
+        .returns([])
+
+      assert.deepEqual(await this.plugin.sendAdminInfo({
+        command: 'settle',
+        amount: '100',
+        account: this.account.getAccount()
+      }), {})
+      assert.deepEqual(sendStub.firstCall.args, [ '100000000', this.from ])
+      assert.deepEqual(callStub.firstCall.args, [
+        'test.example.35YywQ-3GYiO3MM4tvfaSGhty9NZELIBO3kmilL0Wak',
+        {
+         data: {
+           amount: '100000000',
+           protocolData: []
+         },
+         requestId: 12345,
+         type: 7
+        }
+      ])
+    })
+
+    it('should apply a "block" command', async function () {
+      assert.isFalse(this.account.isBlocked())
+      assert.deepEqual(await this.plugin.sendAdminInfo({
+        command: 'block',
+        account: this.account.getAccount()
+      }), {})
+      assert.isTrue(this.account.isBlocked())
+    })
+  })
 })


### PR DESCRIPTION
Implements the interface laid out in https://github.com/interledgerjs/ilp-connector/pull/460

This allows the admin API to see XRP account balance as well as a table of all connected clients and their information. The `sendAdminInfo` function allows you to manually trigger a settlement to an account, or manually block an account.