### PR TITLE
fix: incorrect insufficient liquidity error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -654,9 +654,9 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
         this._bandwidth)
     }
 
-    if (newPrepared.gt(util.xrpToDrops(account.getPaychan().amount))) {
+    if (newPrepared.gt(this.xrpToBase(account.getPaychan().amount))) {
       throw new Errors.InsufficientLiquidityError('Insufficient funds, have: ' +
-        util.xrpToDrops(account.getPaychan().amount) +
+        this.xrpToBase(account.getPaychan().amount) +
         ' need: ' + newPrepared.toString())
     }
 


### PR DESCRIPTION
Was previously getting insufficient liquidity errors when trying to send
payments from a client with asset scale 9 set. The calculation compares
the prepare amount in base units, to the paychan balance in drops. This
was never an issue on the live network because moneyd is still using
asset scale 6.