### PR TITLE
perf: use sodium for signatures and verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 !wallaby.js
 /parallel-2018522*
 /secret
+*.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -343,9 +343,26 @@
       "integrity": "sha512-LIVmqIrIWuiqTvn4RzcrwCOuHo2DD6tKmKBPXXlr4p4n4l6BZBkwFTIa3zu1XkX5MbZgro4a6BvPi+n2Mns5Gg=="
     },
     "bignumber.js": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-6.0.0.tgz",
-      "integrity": "sha512-x247jIuy60/+FtMRvscqfxtVHQf8AGx2hm9c6btkgC0x/hp9yt+teISNhvF8WlwRkCc5yF2fDECH8SIMe8j+GA=="
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+    },
+    "blake2b": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.3.tgz",
+      "integrity": "sha512-pkDss4xFVbMb4270aCyGD3qLv92314Et+FsKzilCLxDz5DuZ2/1g3w4nmBbu6nKApPspnjG7JcwTjGZnduB1yg==",
+      "requires": {
+        "blake2b-wasm": "^1.1.0",
+        "nanoassert": "^1.0.0"
+      }
+    },
+    "blake2b-wasm": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-1.1.7.tgz",
+      "integrity": "sha512-oFIHvXhlz/DUgF0kq5B1CqxIDjIJwh9iDeUUGQUcvgiGz7Wdw03McEO7CfLBy7QKGdsydcMCgO9jFNBAFCtFcA==",
+      "requires": {
+        "nanoassert": "^1.0.0"
+      }
     },
     "bn.js": {
       "version": "4.11.8",
@@ -374,13 +391,12 @@
       "dev": true
     },
     "btp-packet": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/btp-packet/-/btp-packet-2.0.2.tgz",
-      "integrity": "sha512-f0bugIL4DPRSEjd3aSa69p8tWTxXEz5/lH3j/gKwo4BNnmEV2E/uzpZ4rJI2FIKrg7/KyfY/NRdVTbWS865qAg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/btp-packet/-/btp-packet-2.2.0.tgz",
+      "integrity": "sha512-OjmYBdr0AJpeoLZcm8IiOBNvGNtIfqM46JDZVztUosRJGFRtkWlir1BmYtopsRGK9z3fIT9s0NKlqhhAL+vQ1A==",
       "requires": {
-        "bignumber.js": "^7.2.1",
         "dateformat": "^3.0.3",
-        "oer-utils": "^3.0.1"
+        "oer-utils": "^4.0.0"
       },
       "dependencies": {
         "bignumber.js": {
@@ -394,9 +410,9 @@
           "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
         },
         "oer-utils": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-3.1.1.tgz",
-          "integrity": "sha512-Y6+hgPB/yNWJx7WRb4XKin96sTBSAqYPx5p+73X+cAGFuJYupnkwHGTyZvcXPpxGj9rC2oC5uIWDZU8Qdb+Jlw==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-4.0.0.tgz",
+          "integrity": "sha512-WxX0gNGSS0Lzig4IdliHlIQ03PVTpIuLFbOAag5lJrx1hWNG3f/yhx3QOmORpoXe2e53HZbeet8qoOAsiWz5BQ==",
           "requires": {
             "bignumber.js": "^7.2.1"
           }
@@ -1470,13 +1486,13 @@
       }
     },
     "ilp-packet": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-3.0.4.tgz",
-      "integrity": "sha512-8Mr960l6ec2soK9WswRBm/NZZiMMumXLJ3n9SHOi0peeNjsH9oNhgvFWjnpXBWvgX+rwb0ciz8QCMt+2YVhHHQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-3.0.8.tgz",
+      "integrity": "sha512-bi199aq5ptPm+fLybkManwDYZ6nuxxtSZtvTU1xPkzmIoLxAIqc9kBWqT7SXsCUsZ3Py3bZL2RZ79BqjmK5Nvw==",
       "requires": {
         "extensible-error": "^1.0.2",
         "long": "^4.0.0",
-        "oer-utils": "^3.2.0"
+        "oer-utils": "^4.0.0"
       },
       "dependencies": {
         "bignumber.js": {
@@ -1485,9 +1501,9 @@
           "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
         },
         "oer-utils": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-3.2.0.tgz",
-          "integrity": "sha512-WYDTeRW15E1u+hfrIJQwAzLBFu/FAOiMgRa5j/sgrvED0gYbqkKZ4ApQgfdEMiXFzvEmdKQlGcUqmloz6y+WZg==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-4.0.0.tgz",
+          "integrity": "sha512-WxX0gNGSS0Lzig4IdliHlIQ03PVTpIuLFbOAag5lJrx1hWNG3f/yhx3QOmORpoXe2e53HZbeet8qoOAsiWz5BQ==",
           "requires": {
             "bignumber.js": "^7.2.1"
           }
@@ -1581,6 +1597,38 @@
             "uuid-parse": "^1.0.0"
           }
         },
+        "ilp-protocol-ildcp": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ilp-protocol-ildcp/-/ilp-protocol-ildcp-1.0.0.tgz",
+          "integrity": "sha512-rmmrnwUKyVYHwJyteYMF6R6dO6ap1j6c7uNDiCqNLPXQSuNQUwAdXd+7CfStED/mOcM/D86IEZrcNx35GtCt6Q==",
+          "requires": {
+            "ilp-packet": "^2.1.2",
+            "oer-utils": "^1.3.4"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
+              "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg=="
+            },
+            "ilp-packet": {
+              "version": "2.2.0",
+              "resolved": "http://registry.npmjs.org/ilp-packet/-/ilp-packet-2.2.0.tgz",
+              "integrity": "sha1-qHJcwmMxxuLGU1OKEGPVUBQwXjE=",
+              "requires": {
+                "bignumber.js": "^5.0.0",
+                "extensible-error": "^1.0.2",
+                "long": "^3.2.0",
+                "oer-utils": "^1.3.2"
+              }
+            }
+          }
+        },
+        "long": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+          "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+        },
         "ws": {
           "version": "3.3.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
@@ -1614,34 +1662,27 @@
       }
     },
     "ilp-protocol-ildcp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ilp-protocol-ildcp/-/ilp-protocol-ildcp-1.0.0.tgz",
-      "integrity": "sha512-rmmrnwUKyVYHwJyteYMF6R6dO6ap1j6c7uNDiCqNLPXQSuNQUwAdXd+7CfStED/mOcM/D86IEZrcNx35GtCt6Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ilp-protocol-ildcp/-/ilp-protocol-ildcp-2.0.1.tgz",
+      "integrity": "sha512-gkqpS4V6kKht+t40C412mDSMVwJN7jKu2vOROH5WoE3w4EhJWRr4kAqNgEvbJhJiynBLtQkTVi8+OV8XAcPUAQ==",
       "requires": {
-        "ilp-packet": "^2.1.2",
-        "oer-utils": "^1.3.4"
+        "debug": "^3.1.0",
+        "ilp-packet": "^3.0.7",
+        "oer-utils": "^4.0.0"
       },
       "dependencies": {
         "bignumber.js": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
-          "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg=="
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+          "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
         },
-        "ilp-packet": {
-          "version": "2.2.0",
-          "resolved": "http://registry.npmjs.org/ilp-packet/-/ilp-packet-2.2.0.tgz",
-          "integrity": "sha1-qHJcwmMxxuLGU1OKEGPVUBQwXjE=",
+        "oer-utils": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-4.0.0.tgz",
+          "integrity": "sha512-WxX0gNGSS0Lzig4IdliHlIQ03PVTpIuLFbOAag5lJrx1hWNG3f/yhx3QOmORpoXe2e53HZbeet8qoOAsiWz5BQ==",
           "requires": {
-            "bignumber.js": "^5.0.0",
-            "extensible-error": "^1.0.2",
-            "long": "^3.2.0",
-            "oer-utils": "^1.3.2"
+            "bignumber.js": "^7.2.1"
           }
-        },
-        "long": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-          "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
         }
       }
     },
@@ -1675,6 +1716,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "optional": true
     },
     "inquirer": {
       "version": "0.12.0",
@@ -2142,6 +2189,17 @@
       "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
     },
+    "nan": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "optional": true
+    },
+    "nanoassert": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
+      "integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -2175,10 +2233,11 @@
         }
       }
     },
-    "node-addon-api": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.6.2.tgz",
-      "integrity": "sha512-479Bjw9nTE5DdBSZZWprFryHGjUaQC31y1wHo19We/k0BZlrmhqQitWoUL0cD8+scljCbIUL+E58oRDEakdGGA=="
+    "node-gyp-build": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.5.1.tgz",
+      "integrity": "sha512-AKJ4SyHiYvqwy5P9GaAnxi5IG3HSEPHV/1YDMlBA0vEEmi7qxeeSfKlCAau3XFvAPFR9EV6gvD9p2b0s8ghyww==",
+      "optional": true
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -3987,18 +4046,49 @@
         }
       }
     },
+    "siphash24": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/siphash24/-/siphash24-1.1.1.tgz",
+      "integrity": "sha512-dKKwjIoTOa587TARYLlBRXq2lkbu5Iz35XrEVWpelhBP1m8r2BGOy1QlaZe84GTFHG/BTucEUd2btnNc8QzIVA==",
+      "requires": {
+        "nanoassert": "^1.0.0"
+      }
+    },
     "slice-ansi": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
-    "sodium": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/sodium/-/sodium-3.0.2.tgz",
-      "integrity": "sha512-IsTwTJeoNBU97km3XkrbCGC/n/9aUQejgD3QPr2YY2gtbSPru3TI6nhCqgoez9Mv88frF9oVZS/jrXFbd6WXyA==",
+    "sodium-javascript": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.5.5.tgz",
+      "integrity": "sha512-UMmCHovws/sxIBZsIRhIl8uRPou/RFDD0vVop81T1hG106NLLgqajKKuHAOtAP6hflnZ0UrVA2VFwddTd/NQyA==",
       "requires": {
-        "node-addon-api": "*"
+        "blake2b": "^2.1.1",
+        "nanoassert": "^1.0.0",
+        "siphash24": "^1.0.1",
+        "xsalsa20": "^1.0.0"
+      }
+    },
+    "sodium-native": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.2.3.tgz",
+      "integrity": "sha512-0rQvKwlWW86YmmAhosnJ6/2PR3mdAtfuWW147L4x3/gwfL7XiJ7mf2BPvBwU16vsYQNY1yxOQg9YT/MN6qoZOA==",
+      "optional": true,
+      "requires": {
+        "ini": "^1.3.5",
+        "nan": "^2.4.0",
+        "node-gyp-build": "^3.0.0"
+      }
+    },
+    "sodium-universal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-2.0.0.tgz",
+      "integrity": "sha512-csdVyakzHJRyCevY4aZC2Eacda8paf+4nmRGF2N7KxCLKY2Ajn72JsExaQlJQ2BiXJncp44p3T+b80cU+2TTsg==",
+      "requires": {
+        "sodium-javascript": "~0.5.0",
+        "sodium-native": "^2.0.0"
       }
     },
     "source-map": {
@@ -4469,6 +4559,11 @@
       "requires": {
         "base-x": "^1.0.1"
       }
+    },
+    "xsalsa20": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.0.2.tgz",
+      "integrity": "sha512-g1DFmZ5JJ9Qzvt4dMw6m9IydqoCSP381ucU5zm46Owbk3bwmqAr8eEJirOPc7PrXRn45drzOpAyDp8jsnoyXyw=="
     },
     "xtend": {
       "version": "4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -171,7 +171,7 @@
     },
     "@types/events": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
       "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
     },
     "@types/lodash": {
@@ -2175,6 +2175,11 @@
         }
       }
     },
+    "node-addon-api": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.6.2.tgz",
+      "integrity": "sha512-479Bjw9nTE5DdBSZZWprFryHGjUaQC31y1wHo19We/k0BZlrmhqQitWoUL0cD8+scljCbIUL+E58oRDEakdGGA=="
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -3988,6 +3993,14 @@
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
+    "sodium": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sodium/-/sodium-3.0.2.tgz",
+      "integrity": "sha512-IsTwTJeoNBU97km3XkrbCGC/n/9aUQejgD3QPr2YY2gtbSPru3TI6nhCqgoez9Mv88frF9oVZS/jrXFbd6WXyA==",
+      "requires": {
+        "node-addon-api": "*"
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4334,11 +4347,6 @@
       "requires": {
         "tslib": "^1.8.1"
       }
-    },
-    "tweetnacl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
-      "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -25,17 +25,17 @@
   "dependencies": {
     "@types/debug": "0.0.30",
     "base64url": "^3.0.0",
-    "bignumber.js": "^6.0.0",
-    "btp-packet": "^2.0.2",
+    "bignumber.js": "^7.2.1",
+    "btp-packet": "^2.2.0",
     "debug": "^3.1.0",
     "ilp-logger": "^1.0.2",
-    "ilp-packet": "^3.0.4",
+    "ilp-packet": "^3.0.8",
     "ilp-plugin-mini-accounts": "^4.0.1",
     "ilp-plugin-xrp-paychan-shared": "^4.1.0",
-    "ilp-protocol-ildcp": "^1.0.0",
+    "ilp-protocol-ildcp": "^2.0.1",
     "ripple-address-codec": "^2.0.1",
     "ripple-lib": "^0.21.0",
-    "sodium": "^3.0.2",
+    "sodium-universal": "^2.0.0",
     "ws": "^4.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ilp-protocol-ildcp": "^1.0.0",
     "ripple-address-codec": "^2.0.1",
     "ripple-lib": "^0.21.0",
-    "tweetnacl": "^1.0.0",
+    "sodium": "^3.0.2",
     "ws": "^4.0.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import {
   Store
 } from './util'
 
-const sodium = require('sodium')
+const sodium = require('sodium-universal')
 const BtpPacket = require('btp-packet')
 const MiniAccountsPlugin = require('ilp-plugin-mini-accounts')
 
@@ -309,6 +309,16 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
         'reconfigure your uplink to connect with a new payment channel.' +
         ' reason=' + account.getBlockReason())
     }
+    const keyPairHolder = {
+      publicKey: Buffer.alloc(sodium.crypto_sign_PUBLICKEYBYTES),
+      secretKey: Buffer.alloc(sodium.crypto_sign_SECRETKEYBYTES)
+    }
+    sodium.crypto_sign_seed_keypair(
+      keyPairHolder.publicKey,
+      keyPairHolder.secretKey,
+      util.hmac(this._secret, CHANNEL_KEYS + account.getAccount())
+    )
+    this._keyPair = keyPairHolder
 
     if (account.getState() > ReadyState.PREPARING_CHANNEL) {
       try {
@@ -357,9 +367,7 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
       const outgoingAccount = primary.data.toString()
 
       this._log.trace('creating outgoing channel fund transaction')
-      const keyPairSeed = util.hmac(this._secret, CHANNEL_KEYS + account.getAccount())
-      const keyPair = sodium.Key.Sign.fromSeed(keyPairSeed)
-      const publicKey = 'ED' + keyPair.publicKey.baseBuffer.toString('hex').toUpperCase()
+      const publicKey = 'ED' + this._keyPair.publicKey.toString('hex').toUpperCase()
       const txTag = util.randomTag()
 
       const ev = await this._txSubmitter.submit('preparePaymentChannelCreate', {
@@ -468,11 +476,10 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
 
           const fullAccount = this._prefix + account.getAccount()
           const encodedChannelProof = util.encodeChannelProof(channel, fullAccount)
-          const isValid = sodium.Sign.verifyDetached(
-            {
-              sign: channelSignatureProtocol.data,
-              publicKey: Buffer.from(paychan.publicKey.substring(2), 'hex')},
-            encodedChannelProof
+          const isValid = sodium.crypto_sign_verify_detached(
+            channelSignatureProtocol.data,
+            encodedChannelProof,
+            Buffer.from(paychan.publicKey.substring(2), 'hex')
           )
           if (!isValid) {
             throw new Error(`invalid signature for proving channel ownership. ` +
@@ -783,11 +790,8 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
 
     const newDropBalance = util.xrpToDrops(this.baseToXrp(newBalance))
     const encodedClaim = util.encodeClaim(newDropBalance.toString(), clientChannel)
-    const keyPairSeed = util.hmac(this._secret, CHANNEL_KEYS + account.getAccount())
-    const keyPair = sodium.Key.Sign.fromSeed(keyPairSeed)
-    const signer = new sodium.Sign(keyPair)
-    const signature = (signer.sign(encodedClaim)).sign.slice(0, 64)
-
+    const signature = Buffer.alloc(sodium.crypto_sign_BYTES)
+    sodium.crypto_sign_detached(signature, encodedClaim, this._keyPair.secretKey)
     this._log.trace(`signing outgoing claim for ${newDropBalance.toString()} drops on ` +
       `channel ${clientChannel}`)
 
@@ -868,11 +872,10 @@ export default class IlpPluginAsymServer extends MiniAccountsPlugin {
     this._log.trace('handling claim. account=' + account.getAccount(), 'amount=' + dropAmount)
 
     try {
-      valid = sodium.Sign.verifyDetached(
-        {
-          sign: Buffer.from(signature, 'hex'),
-          publicKey: Buffer.from(account.getPaychan().publicKey.substring(2), 'hex')},
-          encodedClaim
+      valid = sodium.crypto_sign_verify_detached(
+          Buffer.from(signature, 'hex'),
+          encodedClaim,
+          Buffer.from(account.getPaychan().publicKey.substring(2), 'hex')
       )
     } catch (err) {
       this._log.debug('verifying signature failed:', err.message)

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -10,7 +10,7 @@ chai.use(chaiAsPromised)
 const assert = chai.assert
 const sinon = require('sinon')
 const debug = require('debug')('ilp-plugin-xrp-asym-server:test')
-const sodium = require('sodium')
+const sodium = require('sodium-universal')
 const EventEmitter = require('events')
 
 const PluginXrpAsymServer = require('..')
@@ -542,7 +542,7 @@ describe('pluginSpec', () => {
       it('should throw if the signature is for a higher amount than the channel max', function () {
         this.claim.amount = 1000001
         // This stub works because require uses a cache
-        this.sinon.stub(require('sodium').Sign, 'verifyDetached')
+        this.sinon.stub(require('sodium-universal'), 'crypto_sign_verify_detached')
           .returns(true)
 
         assert.throws(
@@ -552,7 +552,7 @@ describe('pluginSpec', () => {
 
       it('should not save the claim if it is lower than the previous', function () {
         // This stub works because require uses a cache
-        this.sinon.stub(require('sodium').Sign, 'verifyDetached')
+        this.sinon.stub(require('sodium-universal'), 'crypto_sign_verify_detached')
           .returns(true)
 
         const spy = this.sinon.spy(this.account, 'setIncomingClaim')
@@ -565,7 +565,7 @@ describe('pluginSpec', () => {
       it('should save the claim if it is higher than the previous', function () {
         // This stub works because require uses a cache
         this.claim.amount = 123456
-        this.sinon.stub(require('sodium').Sign, 'verifyDetached')
+        this.sinon.stub(require('sodium-universal'), 'crypto_sign_verify_detached')
           .returns(true)
 
         const spy = this.sinon.spy(this.account, 'setIncomingClaim')
@@ -589,6 +589,10 @@ describe('pluginSpec', () => {
         signature: 'foo'
       })
       this.plugin._store.setCache(this.account.getAccount() + ':outgoing_balance', '12345')
+      this.plugin._keyPair = {
+        publicKey: Buffer.alloc(sodium.crypto_sign_PUBLICKEYBYTES),
+        secretKey: Buffer.alloc(sodium.crypto_sign_SECRETKEYBYTES)
+      }
       this.claim = {
         amount: '12345',
         signature: 'foo'
@@ -622,7 +626,10 @@ describe('pluginSpec', () => {
         beforeEach(function () {
           this.plugin._currencyScale = 9
 
-          this.plugin._keyPair = {}
+          this.plugin._keyPair = {
+            publicKey: Buffer.alloc(sodium.crypto_sign_PUBLICKEYBYTES),
+            secretKey: Buffer.alloc(sodium.crypto_sign_SECRETKEYBYTES)
+          }
           this.plugin._funding = true
           this.plugin._store.setCache(this.account.getAccount() + ':outgoing_balance', '990')
         })
@@ -679,7 +686,8 @@ describe('pluginSpec', () => {
 
         it('should handle a claim', async function () {
           // this stub isn't working, which is why handleMoney is throwing
-          this.sinon.stub(require('sodium').Sign, 'verifyDetached').returns('abcdef')
+          this.sinon.stub(sodium, 'crypto_sign_verify_detached')
+          .returns(true)
           const encodeSpy = this.sinon.spy(util, 'encodeClaim')
 
           this.plugin._store.setCache(this.account.getAccount() + ':balance', 990)

--- a/test/pluginSpec.js
+++ b/test/pluginSpec.js
@@ -10,7 +10,7 @@ chai.use(chaiAsPromised)
 const assert = chai.assert
 const sinon = require('sinon')
 const debug = require('debug')('ilp-plugin-xrp-asym-server:test')
-const nacl = require('tweetnacl')
+const sodium = require('sodium')
 const EventEmitter = require('events')
 
 const PluginXrpAsymServer = require('..')
@@ -542,7 +542,7 @@ describe('pluginSpec', () => {
       it('should throw if the signature is for a higher amount than the channel max', function () {
         this.claim.amount = 1000001
         // This stub works because require uses a cache
-        this.sinon.stub(require('tweetnacl').sign.detached, 'verify')
+        this.sinon.stub(require('sodium').Sign, 'verifyDetached')
           .returns(true)
 
         assert.throws(
@@ -552,7 +552,7 @@ describe('pluginSpec', () => {
 
       it('should not save the claim if it is lower than the previous', function () {
         // This stub works because require uses a cache
-        this.sinon.stub(require('tweetnacl').sign.detached, 'verify')
+        this.sinon.stub(require('sodium').Sign, 'verifyDetached')
           .returns(true)
 
         const spy = this.sinon.spy(this.account, 'setIncomingClaim')
@@ -565,7 +565,7 @@ describe('pluginSpec', () => {
       it('should save the claim if it is higher than the previous', function () {
         // This stub works because require uses a cache
         this.claim.amount = 123456
-        this.sinon.stub(require('tweetnacl').sign.detached, 'verify')
+        this.sinon.stub(require('sodium').Sign, 'verifyDetached')
           .returns(true)
 
         const spy = this.sinon.spy(this.account, 'setIncomingClaim')
@@ -621,8 +621,6 @@ describe('pluginSpec', () => {
       describe('with high scale', function () {
         beforeEach(function () {
           this.plugin._currencyScale = 9
-
-          this.sinon.stub(nacl.sign, 'detached').returns('abcdef')
 
           this.plugin._keyPair = {}
           this.plugin._funding = true
@@ -681,7 +679,7 @@ describe('pluginSpec', () => {
 
         it('should handle a claim', async function () {
           // this stub isn't working, which is why handleMoney is throwing
-          this.sinon.stub(nacl.sign.detached, 'verify').returns('abcdef')
+          this.sinon.stub(require('sodium').Sign, 'verifyDetached').returns('abcdef')
           const encodeSpy = this.sinon.spy(util, 'encodeClaim')
 
           this.plugin._store.setCache(this.account.getAccount() + ':balance', 990)


### PR DESCRIPTION
We were benchmarking the plugins and found tweetnacl to be the biggest bottleneck for `xrp-asym`. Using sodium provides a roughly 100x speed improvement for signing and verifying paychan claims. 

https://gist.github.com/karzak/4b5bdec36d0d0e2f96a1274280416aa5

https://github.com/sodium-friends/sodium-universal

Edit: Using sodium-universal to preserve potential browser compatibility for asym-client (this keeps the two plugins using the same library). 